### PR TITLE
Remove kamon-core dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
-  "io.kamon" %% "kamon-core" % "0.6.7",
   "io.prometheus" % "simpleclient" % prometheusVersion,
   "io.prometheus" % "simpleclient_common" % prometheusVersion,
   "com.typesafe" % "config" % "1.3.1",

--- a/src/main/scala/akka/monitor/instrumentation/ActorMonitor.scala
+++ b/src/main/scala/akka/monitor/instrumentation/ActorMonitor.scala
@@ -19,12 +19,11 @@ package akka.monitor.instrumentation
 import org.aspectj.lang.ProceedingJoinPoint
 import org.slf4j.LoggerFactory
 
-import com.workday.prometheus.akka.{ActorGroupMetrics, ActorMetrics, ActorSystemMetrics, RouterMetrics}
+import com.workday.prometheus.akka._
 
 import akka.actor.{ActorRef, ActorSystem, Cell}
 import akka.monitor.instrumentation.ActorMonitors.{TrackedActor, TrackedRoutee}
 import io.prometheus.client.Collector
-import kamon.metric.Entity
 
 trait ActorMonitor {
   def captureEnvelopeContext(): EnvelopeContext

--- a/src/main/scala/akka/monitor/instrumentation/CellInfo.scala
+++ b/src/main/scala/akka/monitor/instrumentation/CellInfo.scala
@@ -16,11 +16,10 @@
  */
 package akka.monitor.instrumentation
 
-import com.workday.prometheus.akka.MetricsConfig
+import com.workday.prometheus.akka.{Entity, MetricsConfig}
 
 import akka.actor.{ActorRef, ActorSystem, Cell}
 import akka.routing.{NoRouter, RoutedActorRef}
-import kamon.metric.Entity
 
 case class CellInfo(entity: Entity, actorSystemName: String, isRouter: Boolean, isRoutee: Boolean, isTracked: Boolean,
     trackingGroups: List[String], actorCellCreation: Boolean)

--- a/src/main/scala/akka/monitor/instrumentation/RouterMonitor.scala
+++ b/src/main/scala/akka/monitor/instrumentation/RouterMonitor.scala
@@ -18,10 +18,9 @@ package akka.monitor.instrumentation
 
 import org.aspectj.lang.ProceedingJoinPoint
 
-import com.workday.prometheus.akka.RouterMetrics
+import com.workday.prometheus.akka.{Entity, RouterMetrics}
 
 import akka.actor.Cell
-import kamon.metric.Entity
 
 trait RouterMonitor {
   def processMessage(pjp: ProceedingJoinPoint): AnyRef

--- a/src/main/scala/com/workday/prometheus/akka/ActorMetrics.scala
+++ b/src/main/scala/com/workday/prometheus/akka/ActorMetrics.scala
@@ -19,7 +19,6 @@ package com.workday.prometheus.akka
 import scala.collection.JavaConverters._
 
 import io.prometheus.client._
-import kamon.metric.Entity
 
 object ActorMetrics {
   private val map = new java.util.concurrent.ConcurrentHashMap[Entity, ActorMetrics]().asScala

--- a/src/main/scala/com/workday/prometheus/akka/Entity.scala
+++ b/src/main/scala/com/workday/prometheus/akka/Entity.scala
@@ -1,0 +1,37 @@
+/*
+ * =========================================================================================
+ * Copyright © 2017,2018 Workday, Inc.
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+package com.workday.prometheus.akka
+
+import org.slf4j.LoggerFactory
+
+case class Entity(name: String, category: String, tags: Map[String, String]) {
+  if(name == null) Entity.log.warn("Entity with name=null created (category: {}), your monitoring will not work as expected!", category)
+}
+
+object Entity {
+
+  private lazy val log = LoggerFactory.getLogger(classOf[Entity])
+
+  def apply(name: String, category: String): Entity =
+    apply(name, category, Map.empty)
+
+  def create(name: String, category: String): Entity =
+    apply(name, category, Map.empty)
+
+  def create(name: String, category: String, tags: Map[String, String]): Entity =
+    new Entity(name, category, tags)
+}

--- a/src/main/scala/com/workday/prometheus/akka/MetricsConfig.scala
+++ b/src/main/scala/com/workday/prometheus/akka/MetricsConfig.scala
@@ -16,10 +16,8 @@
  */
 package com.workday.prometheus.akka
 
-import com.typesafe.config.{ Config, ConfigFactory, ConfigParseOptions, ConfigResolveOptions }
-
-import kamon.metric.EntityFilter
-import kamon.util.{ GlobPathFilter, RegexPathFilter }
+import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions, ConfigResolveOptions}
+import com.workday.prometheus.akka.impl.{EntityFilter, GlobPathFilter, RegexPathFilter}
 
 object MetricsConfig {
   val Dispatcher = "akka-dispatcher"

--- a/src/main/scala/com/workday/prometheus/akka/RouterMetrics.scala
+++ b/src/main/scala/com/workday/prometheus/akka/RouterMetrics.scala
@@ -19,7 +19,6 @@ package com.workday.prometheus.akka
 import scala.collection.JavaConverters._
 
 import io.prometheus.client.{Counter, Gauge}
-import kamon.metric.Entity
 
 object RouterMetrics {
   private val map = new java.util.concurrent.ConcurrentHashMap[Entity, RouterMetrics]().asScala

--- a/src/main/scala/com/workday/prometheus/akka/impl/EntityFilter.scala
+++ b/src/main/scala/com/workday/prometheus/akka/impl/EntityFilter.scala
@@ -1,0 +1,98 @@
+/*
+ * =========================================================================================
+ * Copyright © 2017,2018 Workday, Inc.
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+package com.workday.prometheus.akka.impl
+
+import java.util.regex.Pattern
+
+private[akka] case class EntityFilter(includes: List[PathFilter], excludes: List[PathFilter]) {
+  def accept(name: String): Boolean =
+    includes.exists(_.accept(name)) && !excludes.exists(_.accept(name))
+}
+
+private[akka] trait PathFilter {
+  def accept(path: String): Boolean
+}
+
+private[akka] case class RegexPathFilter(path: String) extends PathFilter {
+  private val pathRegex = path.r
+  override def accept(path: String): Boolean = {
+    path match {
+      case pathRegex(_*) ⇒ true
+      case _             ⇒ false
+    }
+  }
+}
+
+/**
+  * Default implementation of PathFilter.  Uses glob based includes and excludes to determine whether to export.
+  *
+  * Get a regular expression pattern which accept any path names which match the given glob.  The glob patterns
+  * function similarly to ant file patterns.
+  *
+  * See also: http://ant.apache.org/manual/dirtasks.html#patterns
+  *
+  * @author John E. Bailey
+  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+  */
+private[akka] case class GlobPathFilter(glob: String) extends PathFilter {
+  private val GLOB_PATTERN = Pattern.compile("(\\*\\*?)|(\\?)|(\\\\.)|(/+)|([^*?]+)")
+  private val pattern = getGlobPattern(glob)
+
+  def accept(path: String): Boolean = pattern.matcher(path).matches
+
+  private def getGlobPattern(glob: String) = {
+    val patternBuilder = new StringBuilder
+    val m = GLOB_PATTERN.matcher(glob)
+    var lastWasSlash = false
+    while (m.find) {
+      lastWasSlash = false
+      val grp1 = m.group(1)
+      if (grp1 != null) {
+        // match a * or **
+        if (grp1.length == 2) {
+          // it's a *workers are able to process multiple metrics*
+          patternBuilder.append(".*")
+        }
+        else { // it's a *
+          patternBuilder.append("[^/]*")
+        }
+      }
+      else if (m.group(2) != null) {
+        // match a '?' glob pattern; any non-slash character
+        patternBuilder.append("[^/]")
+      }
+      else if (m.group(3) != null) {
+        // backslash-escaped value
+        patternBuilder.append(Pattern.quote(m.group.substring(1)))
+      }
+      else if (m.group(4) != null) {
+        // match any number of / chars
+        patternBuilder.append("/+")
+        lastWasSlash = true
+      }
+      else {
+        // some other string
+        patternBuilder.append(Pattern.quote(m.group))
+      }
+    }
+    if (lastWasSlash) {
+      // ends in /, append **
+      patternBuilder.append(".*")
+    }
+    Pattern.compile(patternBuilder.toString)
+  }
+}

--- a/src/test/scala/com/workday/prometheus/akka/ActorMetricsSpec.scala
+++ b/src/test/scala/com/workday/prometheus/akka/ActorMetricsSpec.scala
@@ -19,7 +19,6 @@ package com.workday.prometheus.akka
 import akka.actor._
 import akka.monitor.instrumentation.CellInfo
 import akka.testkit.TestProbe
-import kamon.metric.Entity
 
 class ActorMetricsSpec extends TestKitBaseSpec("ActorMetricsSpec") {
 

--- a/src/test/scala/com/workday/prometheus/akka/RouterMetricsSpec.scala
+++ b/src/test/scala/com/workday/prometheus/akka/RouterMetricsSpec.scala
@@ -20,7 +20,6 @@ import akka.actor._
 import akka.monitor.instrumentation.CellInfo
 import akka.routing._
 import akka.testkit.TestProbe
-import kamon.metric.Entity
 
 class RouterMetricsSpec extends TestKitBaseSpec("RouterMetricsSpec") {
 

--- a/src/test/scala/com/workday/prometheus/akka/impl/GlobPathFilterSpec.scala
+++ b/src/test/scala/com/workday/prometheus/akka/impl/GlobPathFilterSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * =========================================================================================
+ * Copyright © 2017,2018 Workday, Inc.
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+package com.workday.prometheus.akka.impl
+
+import org.scalatest.{Matchers, WordSpecLike}
+
+class GlobPathFilterSpec extends WordSpecLike with Matchers {
+  "The GlobPathFilter" should {
+
+    "match a single expression" in {
+      val filter = new GlobPathFilter("/user/actor")
+
+      filter.accept("/user/actor") shouldBe true
+
+      filter.accept("/user/actor/something") shouldBe false
+      filter.accept("/user/actor/somethingElse") shouldBe false
+    }
+
+    "match all expressions in the same level" in {
+      val filter = new GlobPathFilter("/user/*")
+
+      filter.accept("/user/actor") shouldBe true
+      filter.accept("/user/otherActor") shouldBe true
+
+      filter.accept("/user/something/actor") shouldBe false
+      filter.accept("/user/something/otherActor") shouldBe false
+    }
+
+    "match all expressions in the same levelss" in {
+      val filter = new GlobPathFilter("**")
+
+      filter.accept("GET: /ping") shouldBe true
+      filter.accept("GET: /ping/pong") shouldBe true
+    }
+
+    "match all expressions and crosses the path boundaries" in {
+      val filter = new GlobPathFilter("/user/actor-**")
+
+      filter.accept("/user/actor-") shouldBe true
+      filter.accept("/user/actor-one") shouldBe true
+      filter.accept("/user/actor-one/other") shouldBe true
+
+      filter.accept("/user/something/actor") shouldBe false
+      filter.accept("/user/something/otherActor") shouldBe false
+    }
+
+    "match exactly one character" in {
+      val filter = new GlobPathFilter("/user/actor-?")
+
+      filter.accept("/user/actor-1") shouldBe true
+      filter.accept("/user/actor-2") shouldBe true
+      filter.accept("/user/actor-3") shouldBe true
+
+      filter.accept("/user/actor-one") shouldBe false
+      filter.accept("/user/actor-two") shouldBe false
+      filter.accept("/user/actor-tree") shouldBe false
+    }
+  }
+}

--- a/src/test/scala/com/workday/prometheus/akka/impl/RegexPathFilterSpec.scala
+++ b/src/test/scala/com/workday/prometheus/akka/impl/RegexPathFilterSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * =========================================================================================
+ * Copyright © 2017,2018 Workday, Inc.
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+package com.workday.prometheus.akka.impl
+
+import org.scalatest.{Matchers, WordSpecLike}
+
+class RegexPathFilterSpec extends WordSpecLike with Matchers {
+  "The RegexPathFilter" should {
+
+    "match a single expression" in {
+      val filter = new RegexPathFilter("/user/actor")
+
+      filter.accept("/user/actor") shouldBe true
+
+      filter.accept("/user/actor/something") shouldBe false
+      filter.accept("/user/actor/somethingElse") shouldBe false
+    }
+
+    "match arbitray expressions ending with wildcard" in {
+      val filter = new RegexPathFilter("/user/.*")
+
+      filter.accept("/user/actor") shouldBe true
+      filter.accept("/user/otherActor") shouldBe true
+      filter.accept("/user/something/actor") shouldBe true
+      filter.accept("/user/something/otherActor") shouldBe true
+
+      filter.accept("/otheruser/actor") shouldBe false
+      filter.accept("/otheruser/otherActor") shouldBe false
+      filter.accept("/otheruser/something/actor") shouldBe false
+      filter.accept("/otheruser/something/otherActor") shouldBe false
+    }
+
+    "match numbers" in {
+      val filter = new RegexPathFilter("/user/actor-\\d")
+
+      filter.accept("/user/actor-1") shouldBe true
+      filter.accept("/user/actor-2") shouldBe true
+      filter.accept("/user/actor-3") shouldBe true
+
+      filter.accept("/user/actor-one") shouldBe false
+      filter.accept("/user/actor-two") shouldBe false
+      filter.accept("/user/actor-tree") shouldBe false
+    }
+  }
+}


### PR DESCRIPTION
With the kamon 1.0.0 release, the code that prometheus-akka relies on from kamon-core either needs to be changed to match the kamon-core code changes or the kamon 0.6 code that we need can be copied into prometheus-akka. 